### PR TITLE
Bump 5.2

### DIFF
--- a/ppxlib_jane.opam
+++ b/ppxlib_jane.opam
@@ -12,7 +12,7 @@ build: [
 depends: [
   "ocaml" {>= "5.1.0"}
   "dune"   {>= "3.11.0"}
-  "ppxlib" {>= "0.33.0"}
+  "ppxlib" {>= "0.36.0"}
 ]
 available: arch != "arm32" & arch != "x86_32"
 synopsis: "Utilities for working with Jane Street AST constructs"

--- a/src/ast_builder.ml
+++ b/src/ast_builder.ml
@@ -8,9 +8,8 @@ include Shim
 module Default = struct
   include Shim
 
-  type function_param = Shim.Pexp_function.function_param
+  type function_param = Shim.Pexp_function.jfunction_param
   type function_constraint = Shim.Pexp_function.function_constraint
-  type function_body = Shim.Pexp_function.function_body
 
   let mktyp ~loc ?(attrs = []) ptyp_desc =
     { ptyp_loc_stack = []; ptyp_attributes = attrs; ptyp_loc = loc; ptyp_desc }
@@ -62,7 +61,7 @@ module Default = struct
     mkpat ~loc ppat_desc
   ;;
 
-  let value_binding = Shim.Value_binding.create
+  let value_binding = Shim.Value_binding.create ~constraint_:None
 
   let pcstr_tuple ~loc modalities_tys =
     Pcstr_tuple

--- a/src/ast_builder.ml
+++ b/src/ast_builder.ml
@@ -373,6 +373,6 @@ end
 
 let make loc : (module S_with_implicit_loc) =
   (module Make (struct
-      let loc = loc
-    end))
+       let loc = loc
+     end))
 ;;

--- a/src/ast_builder_intf.ml
+++ b/src/ast_builder_intf.ml
@@ -133,9 +133,8 @@ module type S = sig
       case; the nested [function]s are treated as unary. (See the last example.)
   *)
 
-  type function_param = Shim.Pexp_function.function_param
+  type function_param = Shim.Pexp_function.jfunction_param
   type function_constraint = Shim.Pexp_function.function_constraint
-  type function_body = Shim.Pexp_function.function_body
 
   module Latest : sig
     (** Avoid shadowing [pexp_function] in Ppxlib's AST builder. *)

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,10 @@
 (library
  (name ppxlib_jane)
  (public_name ppxlib_jane)
- (libraries compiler-libs.common ppxlib.ast ppxlib.astlib
-   ppxlib.traverse_builtins ppxlib.stdppx)
+ (libraries
+  compiler-libs.common
+  ppxlib.ast
+  ppxlib.astlib
+  ppxlib.traverse_builtins
+  ppxlib.stdppx)
  (preprocess no_preprocessing))

--- a/src/legacy_pexp_function.ml
+++ b/src/legacy_pexp_function.ml
@@ -18,9 +18,9 @@ type t =
   | Legacy_pexp_newtype of legacy_pexp_newtype
 
 let of_pexp_function
-  ~(params : Shim.Pexp_function.jfunction_param list)
-  ~(constraint_ : Shim.Pexp_function.function_constraint option)
-  ~(body : function_body)
+      ~(params : Shim.Pexp_function.jfunction_param list)
+      ~(constraint_ : Shim.Pexp_function.function_constraint option)
+      ~(body : function_body)
   =
   match params, body with
   | [], Pfunction_cases (cases, _, _) -> Legacy_pexp_function cases

--- a/src/legacy_pexp_function.ml
+++ b/src/legacy_pexp_function.ml
@@ -18,9 +18,9 @@ type t =
   | Legacy_pexp_newtype of legacy_pexp_newtype
 
 let of_pexp_function
-  ~(params : Shim.Pexp_function.function_param list)
+  ~(params : Shim.Pexp_function.jfunction_param list)
   ~(constraint_ : Shim.Pexp_function.function_constraint option)
-  ~(body : Shim.Pexp_function.function_body)
+  ~(body : function_body)
   =
   match params, body with
   | [], Pfunction_cases (cases, _, _) -> Legacy_pexp_function cases

--- a/src/legacy_pexp_function.mli
+++ b/src/legacy_pexp_function.mli
@@ -37,9 +37,9 @@ type t =
 val of_parsetree : expression_desc -> t option
 
 val of_pexp_function
-  :  params:Shim.Pexp_function.function_param list
+  :  params:Shim.Pexp_function.jfunction_param list
   -> constraint_:Shim.Pexp_function.function_constraint option
-  -> body:Shim.Pexp_function.function_body
+  -> body:function_body
   -> t
 
 (** Testing a particular constructor of [t]. *)

--- a/src/names.ml
+++ b/src/names.ml
@@ -16,6 +16,7 @@ module Language_feature_name = struct
     | Ptyp_poly _ -> "explicit polymorphic type"
     | Ptyp_package _ -> "first-class module type"
     | Ptyp_extension _ -> "extension point as a type"
+    | Ptyp_open _ -> "local module open"
   ;;
 
   let of_expression_desc : Shim.Expression_desc.t -> string = function
@@ -161,6 +162,7 @@ module Language_feature_name = struct
     | Pmod_unpack _ -> "'val' unpacking of expression as module"
     | Pmod_extension _ -> "extension point as module"
     | Pmod_instance _ -> "module instance"
+    | Pmod_apply_unit _ -> "generative functor"
   ;;
 end
 
@@ -179,6 +181,7 @@ module Constructor_name = struct
     | Ptyp_poly _ -> "Ptyp_poly"
     | Ptyp_package _ -> "Ptyp_package"
     | Ptyp_extension _ -> "Ptyp_extension"
+    | Ptyp_open _ -> "Ptyp_open"
   ;;
 
   let of_expression_desc : Shim.Expression_desc.t -> string = function
@@ -304,5 +307,6 @@ module Constructor_name = struct
     | Pmod_unpack _ -> "Pmod_unpack"
     | Pmod_extension _ -> "Pmod_extension"
     | Pmod_instance _ -> "Pmod_instance"
+    | Pmod_apply_unit _ -> "Pmod_apply_unit"
   ;;
 end

--- a/src/shim.ml
+++ b/src/shim.ml
@@ -80,7 +80,12 @@ module Value_binding = struct
   let extract_modes vb = [], vb
 
   let create ~loc ~constraint_ ~pat ~expr ~modes:_ =
-    { pvb_pat = pat; pvb_expr = expr; pvb_attributes = []; pvb_loc = loc; pvb_constraint = constraint_ }
+    { pvb_pat = pat
+    ; pvb_expr = expr
+    ; pvb_attributes = []
+    ; pvb_loc = loc
+    ; pvb_constraint = constraint_
+    }
   ;;
 end
 
@@ -148,22 +153,35 @@ module Pexp_function = struct
     }
 
   let to_parsetree ~params ~constraint_ ~body =
-    let to_function_params : jfunction_param -> function_param = fun v -> match v.pparam_desc with
-      | Pparam_newtype (ty, _) -> { pparam_desc = Pparam_newtype ty; pparam_loc = v.pparam_loc }
-      | Pparam_val (lbl, e, p) -> { pparam_desc = Pparam_val (lbl, e, p); pparam_loc = v.pparam_loc }
+    let to_function_params : jfunction_param -> function_param =
+      fun v ->
+      match v.pparam_desc with
+      | Pparam_newtype (ty, _) ->
+        { pparam_desc = Pparam_newtype ty; pparam_loc = v.pparam_loc }
+      | Pparam_val (lbl, e, p) ->
+        { pparam_desc = Pparam_val (lbl, e, p); pparam_loc = v.pparam_loc }
     in
-    let type_constraint = Option.map (fun v -> v.type_constraint) constraint_ in 
-    Pexp_function (List.map to_function_params params, type_constraint, body) 
+    let type_constraint = Option.map (fun v -> v.type_constraint) constraint_ in
+    Pexp_function (List.map to_function_params params, type_constraint, body)
   ;;
 
   let of_parsetree =
-    let to_jfunction_params : function_param -> jfunction_param = fun v -> match v.pparam_desc with
-      | Pparam_newtype ty -> { pparam_desc = Pparam_newtype (ty, None); pparam_loc = v.pparam_loc }
-      | Pparam_val (lbl, e, p) -> { pparam_desc = Pparam_val (lbl, e, p); pparam_loc = v.pparam_loc }
-    in fun expr_desc ~loc ->
+    let to_jfunction_params : function_param -> jfunction_param =
+      fun v ->
+      match v.pparam_desc with
+      | Pparam_newtype ty ->
+        { pparam_desc = Pparam_newtype (ty, None); pparam_loc = v.pparam_loc }
+      | Pparam_val (lbl, e, p) ->
+        { pparam_desc = Pparam_val (lbl, e, p); pparam_loc = v.pparam_loc }
+    in
+    fun expr_desc ~loc ->
       match expr_desc with
       | Pexp_function (params, constraint_, body) ->
-        let function_constraint = Option.map (fun type_constraint -> { type_constraint; mode_annotations = [] }) constraint_ in
+        let function_constraint =
+          Option.map
+            (fun type_constraint -> { type_constraint; mode_annotations = [] })
+            constraint_
+        in
         Some (List.map to_jfunction_params params, function_constraint, body)
       | _ -> None
   ;;
@@ -263,7 +281,7 @@ module Core_type = struct
     }
 
   let of_parsetree
-    { Ppxlib_ast.Parsetree.ptyp_desc; ptyp_loc; ptyp_loc_stack; ptyp_attributes }
+        { Ppxlib_ast.Parsetree.ptyp_desc; ptyp_loc; ptyp_loc_stack; ptyp_attributes }
     =
     let ptyp_desc = Core_type_desc.of_parsetree ptyp_desc in
     { ptyp_desc; ptyp_loc; ptyp_loc_stack; ptyp_attributes }
@@ -488,7 +506,7 @@ module Expression_desc = struct
     | Some (x1, x2, x3) -> Pexp_function (x1, x2, x3)
     | None ->
       (match expr_desc with
-       | Pexp_function _ -> 
+       | Pexp_function _ ->
          (* matched by above call to [of_parsetree] *)
          assert false
        | Pexp_constraint (x1, x2) -> Pexp_constraint (x1, Some x2, [])
@@ -808,9 +826,9 @@ module Ast_traverse = struct
       }
 
     and function_constraint = Pexp_function.function_constraint =
-    { mode_annotations : Modes.t
-    ; type_constraint : type_constraint
-    }
+      { mode_annotations : Modes.t
+      ; type_constraint : type_constraint
+      }
 
     and mode = Mode.t = Mode of string [@@unboxed]
     and modes = mode loc list
@@ -1402,7 +1420,7 @@ module Ast_traverse = struct
                 [ "pparam_loc", Stdlib.snd pparam_loc
                 ; "pparam_desc", Stdlib.snd pparam_desc
                 ] )
-       
+
         method function_constraint
           : 'ctx -> function_constraint -> function_constraint * 'res =
           fun ctx { mode_annotations; type_constraint } ->

--- a/src/shim.mli
+++ b/src/shim.mli
@@ -179,7 +179,7 @@ module Core_type_desc : sig
     | Ptyp_poly of (string loc * jkind_annotation option) list * core_type
     | Ptyp_package of package_type
     | Ptyp_extension of extension
-    | Ptyp_open of Longident.t loc * core_type 
+    | Ptyp_open of Longident.t loc * core_type
 
   val of_parsetree : core_type_desc -> t
   val to_parsetree : t -> core_type_desc


### PR DESCRIPTION
Hi! 

With the [release of ppxlib.0.36.0](https://github.com/ocaml/opam-repository/pull/27478) the full 5.2 AST is now supported upstream. For ppxlib_jane this mostly means the shimming of functions needs to use slightly more of upstream except for those bits with mode annotations.

Some awkward bits are that function parameters now name clash with upstream function parameters. 